### PR TITLE
about content

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -1,9 +1,105 @@
 ---
-layout: layouts/page
-title: About Me
-eleventyNavigation:
-  key: About Me
-  order: 3
+categories:
+- uncategorized
+date: '2020-07-10T14:36:24'
+date_gmt: '2020-07-10T18:36:24'
+excerpt: |-
+  Who developed Data.gov? With what technology is Data.gov built? What standards were used to develop the metadata displayed on Data.gov? How are the datasets on Data.gov collected? …
+link: https://www.data.gov/about
+slug: uncategorized__about
+title: About Data.gov
+layout: layouts/page.html
 ---
 
-I am a person that writes stuff.
+[About data.gov](#about)
+
+- [Who developed Data.gov?](#who)
+- [With what technology is Data.gov built?](#technology)
+- [What standards were used to develop the metadata displayed on Data.gov?](#standards)
+
+[Get Data on Data.gov](#adddata)
+- [How are the datasets on Data.gov collected?](#collected)
+
+[Data.gov Search & Feedback](#search)
+
+- [How do I find data on Data.gov?](#finddata)
+- [What if I am having difficulty downloading a dataset from the catalog?](#difficulty)
+- [Media Inquiries](#media)
+
+<h1 id="about">{{ title }}</h1>
+
+<h2 id="who">Who developed Data.gov?</h2>
+
+Data.gov was launched in 2009 and is managed and hosted by the U.S. General Services Administration, [Technology Transformation Service](http://www.gsa.gov/portal/category/25729).
+
+[Top](#top)
+
+
+<h2 id="technology">With what technology is Data.gov built?</h2>
+
+Data.gov is powered by two open source applications, [CKAN](http://ckan.org/) and [WordPress,](http://wordpress.org/) and it is developed publicly on [GitHub](https://github.com/GSA/catalog-deploy).
+
+
+<h2 id="standards">What standards were used to develop the metadata displayed on Data.gov?</h2>
+
+Data.gov follows the [DCAT-US Schema v1.1 (Project Open Data Metadata Schema)](https://resources.data.gov/schemas/dcat-us/v1.1/) – a set of required fields (Title, Description, Tags, Last Update, Publisher, Contact Name, etc.) for every data set displayed on Data.gov.
+
+[Top](#top)
+
+
+<h1 id="adddata">Get Data on Data.gov</h2>
+
+
+<h2 id="collected">How are the datasets on Data.gov collected?</h2>
+
+
+Under the OPEN Government Data Act, which is Title II of the [Foundations for Evidence-Based Policymaking Act,](https://www.congress.gov/115/plaws/publ435/PLAW-115publ435.pdf) government data is required to be made available in open, machine-readable formats, while continuing to ensure privacy and security.
+
+
+__Government data publishers looking to get their data on Data.gov should read the detailed guide:__ [__How to get your open data on Data.gov__](https://resources.data.gov/tools/how-to-get-your-open-data-on-datagov/). The Data.gov team typically works with a designated open data point of contact as a liaison for each agency. Data publishers should consult with their agency point of contact to include any additional datasets on Data.gov. If you need help determining who your open data point of contact is, please [contact us](http://www.data.gov/contact).
+
+
+Federal agencies are required to:
+
+
+- __Create a Single Agency Data Inventory.__ Agencies are required to catalog their data assets, just like they would inventory computers or desk chairs, to better manage and use these resources.
+- __Publish a Public Data Listing.__ Agencies are required to publish a list of their data assets that are public, or could be made public. This list is made available as a data.json hosted at the primary domain of the agency (e.g.)
+[gsa.gov/data.json](https://open.gsa.gov/data.json)
+
+
+
+[Agency Public Data Listings are made available on agency websites as JSON files following the](https://open.gsa.gov/data.json) [DCAT-US Schema v1.1](https://resources.data.gov/resources/dcat-us/);(at agency.gov/data.json) and are then harvested into the central catalog for Data.gov.  Each agency is responsible for its own data.
+
+[Top](#top)
+
+
+<h1 id="search">Data.gov Search & Feedback</h2>
+
+<h2 id="finddata">How do I find data on Data.gov?</h2>
+
+You can [search Data.gov](http://www.data.gov/) from its [catalog of government data](http://catalog.data.gov/dataset#topic=uncategorized_navigation) from across the Federal Government. Once in the catalog, to find datasets you can:
+
+
+- Enter keywords in the search box.
+- Browse on the left side through types, tags, formats, groups, organization types, organizations, and categories.  Clicking on multiple items narrows your search.  You can click on the “x” to the side of any single item to remove it from the search, or “clear all” to remove all selected items in a category.
+- Search by geospatial area by drawing a boundary box on the map at the left side and clicking “Apply” to find all datasets that are tagged for that geographic area.
+- Once you find a dataset or tool of interest, click on the title and you will be taken to a page with more details on that specific dataset or tool. Some datasets are downloadable, while others are links to web sites or apps that help you access or use the data.
+
+Please note that by accessing datasets or tools offered on Data.gov, you agree to the [Data Policy](http://www.data.gov/data-policy), which you should read before accessing any data. If there are additional datasets that you would like to see included on this site, please [suggest more datasets here](https://www.data.gov/data-request/).
+
+
+[Top](#top)
+
+<h2 id="difficulty">What if I am having difficulty downloading a dataset from the catalog?</h2>
+
+
+Please tell us what the [problem with the dataset](http://www.data.gov/issue/) is so that we can correct it.
+
+[Top](#top)
+
+<h2 id="media">Media inquiries</h2>
+
+
+If you are preparing an article or creating an event, and are interested in finding information, a speaker, or other help in communicating about open data, contact the Data.gov team at [datagov@gsa.gov](mailto:datagov@gsa.gov).
+
+[Top](#top)

--- a/about/index.md
+++ b/about/index.md
@@ -11,6 +11,8 @@ title: About Data.gov
 layout: layouts/page.html
 ---
 
+<div id="top"></div>
+
 [About data.gov](#about)
 
 - [Who developed Data.gov?](#who)


### PR DESCRIPTION
## Changes proposed in this pull request:

roughs in content from the about page of data.gov

no styling, some attention needed for headers and links

![image](https://user-images.githubusercontent.com/2480492/181018020-934fe8a4-e95a-46ee-b4e4-eceeae9a959b.png)

[alt text: image of a table of contents with links to things like "who developed data.gov?" Below are some headings and a few lines of content of the actual about material
