### PR TITLE
Add Maritime main page and sub-pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,11 @@ permalink: /
 layout: layouts/wide
 title: Data.gov Home
 tagline: The home of the U.S. Government's open data
-
+pagination:
+  data: collections.post
+  size: 300
+  alias: posts
+  reverse: true
 ---
 <section class="usa-section">
   <div class="grid-container">
@@ -20,9 +24,9 @@ tagline: The home of the U.S. Government's open data
     <h2>Recent updates</h2>
     <a class="updates-link" href="updates">Browse all updates</a>
 
-    {% for post in collections.post reversed limit: 3 %}
-      {% include "update.html", post: post %}
-    {% endfor %}
+    {%- for post in posts limit: 3 -%}
+      {%- include "update.html", post: post -%}
+    {%- endfor -%}
 
     <a class="updates-link" href="updates">Browse all updates</a>
   </div>

--- a/posts/2013-12-16-cities.md
+++ b/posts/2013-12-16-cities.md
@@ -1,4 +1,5 @@
 ---
+date: '2013-12-16T08:47:52'
 categories:
 - cities
 link: https://www.data.gov/cities/

--- a/posts/2016-10-19-a-maritime-topic-for-a-maritime-nation.md
+++ b/posts/2016-10-19-a-maritime-topic-for-a-maritime-nation.md
@@ -1,0 +1,17 @@
+---
+author: marin-m-kressusace-army-mil
+categories:
+- maritime
+tags: maritime
+date: '2016-10-19T19:37:31'
+excerpt: |-
+    We are excited to launch the Maritime Topic on Data.gov, a place where the diverse datasets…
+link: https://www.data.gov/maritime/a-maritime-topic-for-a-maritime-nation/
+modified: '2016-11-30T01:14:52'
+permalink: /maritime/a-maritime-topic-for-a-maritime-nation/
+slug: a-maritime-topic-for-a-maritime-nation
+title: A Maritime Topic for a Maritime Nation
+---
+
+We are excited to launch the Maritime Topic on Data.gov, a place where the diverse datasets relevant to maritime transportation can be shared and discovered.  The marine transportation system connects people around the world, moving energy commodities, consumer goods, and agricultural products from producers to markets – and don’t forget the cruise ships that move millions of vacationers every year.  With [over 28 U.S. Federal Government departments, agencies, bureaus, and independent commissions](https://www.cmts.gov/) involved in the marine transportation system there is a wealth of existing data on topics ranging from [marine mammals](https://catalog.data.gov/dataset/large-whale-incident-database) to [trust fund revenues](https://catalog.data.gov/dataset/trust-fund-financial-reports-70249).  Whatever your interest in marine transportation we hope the Maritime Topic helps point you towards the right data for your question.  Check back for updates, highlighted datasets, and examples of how maritime data is being used across the public and private sectors.
+

--- a/posts/2021-10-01-data-policy.md
+++ b/posts/2021-10-01-data-policy.md
@@ -1,5 +1,6 @@
 ---
-date: '2021-10-01T17:15:15'
+author: admin
+date: '2009-10-01T17:15:15'
 excerpt: '<p>Privacy Policy Information Collected and Stored Automatically Cookies
   Personal Information Online Comments Moderation of Comments and Posts Site Security
   External Links Children&#8217;s Privacy Prohibitions Changes to this Policy Data

--- a/posts/contact.md
+++ b/posts/contact.md
@@ -1,4 +1,5 @@
 ---
+date: '2009-10-01T17:15:15'
 layout: layouts/post
 excerpt: 'Thank you for your feedback. To protect your privacy, please do not include
   personal information (such as a social security number), other than your email address.'

--- a/topics/maritime.html
+++ b/topics/maritime.html
@@ -1,0 +1,29 @@
+---
+author: admin
+categories:
+- maritime
+excerpt: |-
+  Main Page for Maritimeupdates
+link: https://www.data.gov/maritime/
+layout: layouts/update-index
+
+pagination:
+  data: collections.maritime
+  size: 10
+  alias: posts
+  reverse: true
+permalink: "/maritime/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber | plus: 1 }}/index.html{% endif %}"
+
+slug: marittime
+title: Maritime
+---
+
+{% include "pagination-links.html" %}
+
+Discover datasets for marine transportation, a critical part of our transportation system used for domestic and international trade, national security, research, and recreation. Explore data related to mapping and charting, energy use, commodity movement, international trade and finance, environmental sustainability, and more.
+
+{%- for post in posts %}
+  {% include "update.html", post: post %}
+{%- endfor %}
+
+{% include "pagination-links.html" %}

--- a/topics/maritime.html
+++ b/topics/maritime.html
@@ -14,7 +14,7 @@ pagination:
   reverse: true
 permalink: "/maritime/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber | plus: 1 }}/index.html{% endif %}"
 
-slug: marittime
+slug: maritime
 title: Maritime
 ---
 


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/3891


## Changes in this pull request:
- Add Maritime main page.
- Fix the order of the update list.
- Add/change the date for data-policy, contact and cities pages.
- Add content for 'a maritime topic for a maritime nation' page which is Replaces 
   https://github.com/GSA/datagov-website/blob/main/www.data.gov/maritime/posts/a-maritime-topic-for-a-maritime-nation/index.html


