### PR TITLE
bump actions versions

### DIFF
--- a/.github/workflows/content_scan.yml
+++ b/.github/workflows/content_scan.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install node.js.
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Related to https://github.com/GSA/data.gov/issues/4005 I guess
- Bump actions versions for `checkout` and `setup-node` to `v3`


## security considerations
[Note the any security considerations here, or make note of why there are none]
