### PR TITLE
Add GSA 'starmark' logo to footer

### DIFF
--- a/_includes/identifier.html
+++ b/_includes/identifier.html
@@ -1,9 +1,14 @@
 <div class="usa-identifier">
     <section class="usa-identifier__section usa-identifier__section--masthead" aria-label="Agency identifier,,,">
-        <div class="usa-identifier__container">
-            <div class="usa-identifier__identity" aria-label="Agency description">
-                <p class="usa-identifier__identity-domain">data.gov</p>
-                <p class="usa-identifier__identity-disclaimer">An official website of the General Services Administration.</p>
+        <div class="grid-container-widescreen display-flex">
+            <div class="usa-identifier__container">
+                <div class="usa-identifier__logos">
+                    <img class="usa-identifier__logo-img" alt="GSA logo" role="img" src="https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/gsa_starmark.png">
+                </div>
+                <div class="usa-identifier__identity" aria-label="Agency description">
+                    <p class="usa-identifier__identity-domain">data.gov</p>
+                    <p class="usa-identifier__identity-disclaimer">An official website of the General Services Administration.</p>
+                </div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/4247

Using https://www.performance.gov/ as an example:
![image](https://user-images.githubusercontent.com/85196563/226932431-9c8ef9a5-6183-428d-bbfe-dadb7d810322.png)
