### PR TITLE
patch vulnerability bump pug to 3.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "pa11y-ci": "^3.1.0",
         "postcss": "^8.4.47",
         "postcss-cli": "^11.0.0",
+        "pug": "^3.0.3",
         "rimraf": "^6.0.1",
         "start-server-and-test": "^2.0.8"
       },
@@ -1803,7 +1804,9 @@
       }
     },
     "node_modules/assert-never": {
-      "version": "1.2.1",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.3.0.tgz",
+      "integrity": "sha512-9Z3vxQ+berkL/JJo0dK+EY3Lp0s3NtSnP3VCLsh5HDcZPrh0M+KQRK5sWhUeyPPH+/RCxZqOxLMR+YC6vlviEQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1924,6 +1927,8 @@
     },
     "node_modules/babel-walk": {
       "version": "3.0.0-canary-5",
+      "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
+      "integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3370,6 +3375,8 @@
     },
     "node_modules/doctypes": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
+      "integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5456,6 +5463,8 @@
     },
     "node_modules/js-stringify": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
+      "integrity": "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==",
       "dev": true,
       "license": "MIT"
     },
@@ -7401,11 +7410,13 @@
       "dev": true
     },
     "node_modules/pug": {
-      "version": "3.0.2",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.3.tgz",
+      "integrity": "sha512-uBi6kmc9f3SZ3PXxqcHiUZLmIXgfgWooKWXcwSGwQd2Zi5Rb0bT14+8CJjJgI8AB+nndLaNgHGrcc6bPIB665g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "pug-code-gen": "^3.0.2",
+        "pug-code-gen": "^3.0.3",
         "pug-filters": "^4.0.0",
         "pug-lexer": "^5.0.1",
         "pug-linker": "^4.0.0",
@@ -7417,6 +7428,8 @@
     },
     "node_modules/pug-attrs": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
+      "integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7426,7 +7439,9 @@
       }
     },
     "node_modules/pug-code-gen": {
-      "version": "3.0.2",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.3.tgz",
+      "integrity": "sha512-cYQg0JW0w32Ux+XTeZnBEeuWrAY7/HNE6TWnhiHGnnRYlCgyAUPoyh9KzCMa9WhcJlJ1AtQqpEYHc+vbCzA+Aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7434,14 +7449,16 @@
         "doctypes": "^1.1.0",
         "js-stringify": "^1.0.2",
         "pug-attrs": "^3.0.0",
-        "pug-error": "^2.0.0",
-        "pug-runtime": "^3.0.0",
+        "pug-error": "^2.1.0",
+        "pug-runtime": "^3.0.1",
         "void-elements": "^3.1.0",
         "with": "^7.0.0"
       }
     },
     "node_modules/pug-error": {
-      "version": "2.0.0",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.1.0.tgz",
+      "integrity": "sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg==",
       "dev": true,
       "license": "MIT"
     },
@@ -7496,6 +7513,8 @@
     },
     "node_modules/pug-runtime": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
+      "integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==",
       "dev": true,
       "license": "MIT"
     },
@@ -9586,6 +9605,8 @@
     },
     "node_modules/void-elements": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9697,6 +9718,8 @@
     },
     "node_modules/with": {
       "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
+      "integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "pa11y-ci": "^3.1.0",
     "postcss": "^8.4.47",
     "postcss-cli": "^11.0.0",
+    "pug": "^3.0.3",
     "rimraf": "^6.0.1",
     "start-server-and-test": "^2.0.8"
   },


### PR DESCRIPTION

Fix https://github.com/GSA/datagov-11ty/security/dependabot/41

## Changes proposed in this pull request:
- add pug 3.0.3 in package.json
- run `npm i --package-lock-only` to update `package-lock.json`
