### PR TITLE
removes top search terms from metrics page

### DIFF
--- a/_data/metrics.js
+++ b/_data/metrics.js
@@ -22,13 +22,7 @@ const REPORTS = {
       description: "",
       url: "global__device_category__last30.csv",
       columnKeys: ["deviceCategory", "activeUsers", "percentage"]
-    },
-    TOP_SEARCH_TERMS: {
-      title: "Top Search Terms",
-      description: "Top onsite search terms (Full report shows top 50 terms)",
-      url: "global__top_search_terms__last30.csv",
-      columnKeys: ["searchTerm", "eventCount"]
-    },    
+    }, 
     DATASETS_PER_ORG: {
       title: "Number of Datasets per Organization",
       description: "Count of datasets by organization",


### PR DESCRIPTION
## Changes proposed in this pull request:

- Resolves: https://github.com/GSA/data.gov/issues/4961

## security considerations
[Note the any security considerations here, or make note of why there are none]
