### PR TITLE
Add dataset page column to global download and outbound tables

### DIFF
--- a/_data/metrics.js
+++ b/_data/metrics.js
@@ -24,6 +24,18 @@ const REPORTS = {
       url: "global__device_category__last30.[end_date].csv",
       columnKeys: ["deviceCategory", "activeUsers", "percentage"]
     }, 
+    MOST_DOWNLOADED_DATASETS: {
+      title: "Most Downloaded Dataset Files",
+      description: "Top 10 downloaded files",
+      url: "global__download_requests__last30.[end_date].csv",
+      columnKeys: ["linkUrl", "eventCount"]
+    },
+    MOST_CLICKED_OUTBOUND_LINKS: {
+      title: "Most Clicked Outbound Links",
+      description: "Top 10 external link clicks",
+      url: "global__link_requests__last30.[end_date].csv",
+      columnKeys: ["linkUrl", "eventCount"]
+    },
     DATASETS_PER_ORG: {
       title: "Number of Datasets per Organization",
       description: "Count of datasets by organization",
@@ -36,6 +48,7 @@ const REPORTS = {
       url: "global__harvest_sources.[end_date].csv",
       columnKeys: ["organization", "count"]
     }
+
   },
   // ORG is a meta constructor for orgs
   ORG: {

--- a/_data/metrics.js
+++ b/_data/metrics.js
@@ -64,7 +64,7 @@ const ENUMS = {
   "deviceCategory": "Device Category",
   "activeUsers": "Users",
   "searchTerm": "Search Term",
-  "pageTitle": "Title",
+  "pageTitle": "Page Title",
   "eventCount": "Count",
   "organization": "Organization",
   "count": "Count",

--- a/_data/metrics.js
+++ b/_data/metrics.js
@@ -28,13 +28,13 @@ const REPORTS = {
       title: "Most Downloaded Dataset Files",
       description: "Top 10 downloaded files",
       url: "global__download_requests__last30.[end_date].csv",
-      columnKeys: ["linkUrl", "eventCount"]
+      columnKeys: ["linkUrl", "pageTitle", "eventCount"]
     },
     MOST_CLICKED_OUTBOUND_LINKS: {
       title: "Most Clicked Outbound Links",
       description: "Top 10 external link clicks",
       url: "global__link_requests__last30.[end_date].csv",
-      columnKeys: ["linkUrl", "eventCount"]
+      columnKeys: ["linkUrl", "pageTitle", "eventCount"]
     },
     DATASETS_PER_ORG: {
       title: "Number of Datasets per Organization",

--- a/pages/metrics/metrics.html
+++ b/pages/metrics/metrics.html
@@ -84,17 +84,19 @@ title: Datagov Metrics Dashboard
           {% for row in block.data offset:1 %}
           <tr>
             {% for column in row %}
-            {%- if block.meta.columnKeys contains block.data[0][forloop.index0] -%}
-            {%- if forloop.first -%}
-            {%- if cacheKey == "DATASETS_PER_ORG" or cacheKey == "HARVEST_SOURCES_PER_ORG" -%}
-              <td><a href="{{helpers.baseUrl}}/metrics/organization/{{column}}/index.html">{{metrics.orgDict[column]}}</a></td>
-              {%- else -%}
-              <td>{{column}}</td>
+              {%- if block.meta.columnKeys contains block.data[0][forloop.index0] -%}
+                {%- if forloop.first -%}
+                  {%- if cacheKey == "DATASETS_PER_ORG" or cacheKey == "HARVEST_SOURCES_PER_ORG" -%}
+                  <td><a href="{{helpers.baseUrl}}/metrics/organization/{{column}}/index.html">{{metrics.orgDict[column]}}</a></td>
+                  {%- elsif cacheKey == "MOST_DOWNLOADED_DATASETS" or cacheKey == "MOST_CLICKED_OUTBOUND_LINKS" -%}
+                  <td><a href="{{column}}">{{column}}</a></td>
+                  {%- else -%}
+                  <td>{{column}}</td>
+                  {%- endif -%}
+                {%- else -%}
+                <td align="right">{{column | toLocaleString}}</td>
+                {%- endif -%}
               {%- endif -%}
-            {%- else -%}
-            <td align="right">{{column | toLocaleString}}</td>
-            {%- endif -%}
-            {%- endif -%}
             {% endfor %}
           </tr>
           {% endfor %}

--- a/pages/metrics/metrics.html
+++ b/pages/metrics/metrics.html
@@ -105,11 +105,11 @@ title: Datagov Metrics Dashboard
                   {%- assign pageURL = 4 -%}
                 {%- endif -%}
                 {%- if block.data[0][forloop.index0] == "pageTitle" -%}
-                  <td align="left">
+                  <td>
                     <a href="{{row[pageURL]}}" target="_blank">{{column | toLocaleString | replace: " - Catalog", ""}}</a>
                   </td>
                 {%- else -%}
-                  <td align="right">{{column | toLocaleString}}</td>
+                  <td>{{column | toLocaleString}}</td>
                 {%- endif -%}
                 {%- endif -%}
 

--- a/pages/metrics/metrics.html
+++ b/pages/metrics/metrics.html
@@ -59,7 +59,11 @@ title: Datagov Metrics Dashboard
       <div class="grid-col-12">
         <h4>{{block.meta.title}}</h4>
         <p>{{block.meta.description}}</p>
-        <table class="usa-table usa-table--borderless usa-table--stacked full-width">
+        {%- if cacheKey == "MOST_DOWNLOADED_DATASETS" or cacheKey == "MOST_CLICKED_OUTBOUND_LINKS"-%}
+          <table class="usa-table usa-table--borderless usa-table--stacked">
+        {%- else -%}
+          <table class="usa-table usa-table--borderless usa-table--stacked full-width"> 
+        {%- endif -%}
           <caption>
             <a href="{{block.meta.reportLink}}">{% usa_icon 'file_download' %} Download Full Report -
               {{block.meta.title}}</a>
@@ -94,8 +98,21 @@ title: Datagov Metrics Dashboard
                   <td>{{column}}</td>
                   {%- endif -%}
                 {%- else -%}
-                <td align="right">{{column | toLocaleString}}</td>
+                
+                {%- if cacheKey == "MOST_DOWNLOADED_DATASETS" -%}
+                  {%- assign pageURL = 5 -%}
+                {%- elsif cacheKey == "MOST_CLICKED_OUTBOUND_LINKS" -%}
+                  {%- assign pageURL = 4 -%}
                 {%- endif -%}
+                {%- if block.data[0][forloop.index0] == "pageTitle" -%}
+                  <td align="left">
+                    <a href="{{row[pageURL]}}" target="_blank">{{column | toLocaleString | replace: " - Catalog", ""}}</a>
+                  </td>
+                {%- else -%}
+                  <td align="right">{{column | toLocaleString}}</td>
+                {%- endif -%}
+                {%- endif -%}
+
               {%- endif -%}
             {% endfor %}
           </tr>

--- a/pages/metrics/metrics_per-org.html
+++ b/pages/metrics/metrics_per-org.html
@@ -26,7 +26,11 @@ eleventyComputed:
       <div class="grid-col-12">
         <h4>{{block.meta.title}}</h4>
         <p>{{block.meta.description}}</p>
-        <table class="usa-table usa-table--borderless usa-table--stacked full-width">
+        {%- if cacheKey == "MOST_VIEWED_DATASETS" -%}
+          <table class="usa-table usa-table--borderless usa-table--stacked full-width">
+        {%- else -%}
+          <table class="usa-table usa-table--borderless usa-table--stacked"> 
+        {%- endif -%}
           <caption>
             <a href="{{block.meta.reportLink}}">{% usa_icon 'file_download' %} Download Full Report -
               {{block.meta.title}}</a>
@@ -60,9 +64,13 @@ eleventyComputed:
             {%- endif -%}
 
             {%- else -%}
-            {%- assign pageURL = 5 -%}
+            {%- if cacheKey == "MOST_DOWNLOADED_DATASETS" -%}
+              {%- assign pageURL = 5 -%}
+            {%- else -%}
+              {%- assign pageURL = 4 -%}
+            {%- endif -%}
             {%- if block.data[0][forloop.index0] == "pageTitle" -%}
-              <td align="right">
+              <td align="left">
               <a href="{{row[pageURL]}}" target="_blank">{{column | toLocaleString | replace: " - Catalog", ""}}</a>
             </td>
             {%- else -%}

--- a/pages/metrics/metrics_per-org.html
+++ b/pages/metrics/metrics_per-org.html
@@ -70,11 +70,11 @@ eleventyComputed:
               {%- assign pageURL = 4 -%}
             {%- endif -%}
             {%- if block.data[0][forloop.index0] == "pageTitle" -%}
-              <td align="left">
+              <td>
               <a href="{{row[pageURL]}}" target="_blank">{{column | toLocaleString | replace: " - Catalog", ""}}</a>
             </td>
             {%- else -%}
-            <td align="right">{{column | toLocaleString}}</td>
+            <td>{{column | toLocaleString}}</td>
             {%- endif -%}
             {%- endif -%}
             {%- endif -%}

--- a/styles/partials/overrides.scss
+++ b/styles/partials/overrides.scss
@@ -124,6 +124,10 @@ button {
     background-color: #fff;
 }
 
+.usa-table td {
+  text-align: left
+}
+
 .usa-table.full-width tr {
     td:first-child {
         width: 90%;


### PR DESCRIPTION
## Changes proposed in this pull request:
- styling fixes
- add dataset page column to global download and outbound tables
- fix correct page title column index for outbound table. download and outbound have different number of columns. 

## security considerations
[Note the any security considerations here, or make note of why there are none]
