### PR TITLE
prepare for the federal shutdown

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -16,7 +16,19 @@ const {
     usaCurrentShortcode,
 } = require('./config/shortCodes');
 
+const isFederalShutdownMode = false;
+
 module.exports = function (config) {
+    if (isFederalShutdownMode) {
+        config.addPassthroughCopy({ 'maintenance/federal-government-shutdown.html': 'index.html' });
+        return {
+            dir: {
+                input: 'maintenance',
+                output: '_site',
+            },
+        };
+    }
+
     // Set pathPrefix for site
     let pathPrefix = '/';
 

--- a/maintenance/federal-government-shutdown.html
+++ b/maintenance/federal-government-shutdown.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>Site Maintenance</title>
+<style>
+  body { text-align: center; padding-top: 100px; }
+  h1 { font-size: 50px; }
+  body { font: 20px Helvetica, sans-serif; color: #333; }
+  article { display: block; text-align: left; width: 650px; margin: 0 auto; }
+  a { color: #dc8100; text-decoration: none; }
+  a:hover { color: #333; text-decoration: none; }
+  img { display: block; width: 200px;}
+</style>
+
+<article>
+  <img src=https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/logo.svg alt="data.gov logo">
+  <h1>Site not available</h1>
+    <div>
+        <p>
+          The Federal Government is currently shut down. As a result, this site is unavailable until further notice. Please visit <a href="https://usa.gov">https://usa.gov</a> for more information.
+        </p>
+    </div>
+</article>


### PR DESCRIPTION
## Changes proposed in this pull request:
- added `isFederalShutdownMode`. 
- added page `maintenance/federal-government-shutdown.html`

`isFederalShutdownMode` stays `false`. When setting it to `true`, all pages will be unavailable, the site will display content from `federal-government-shutdown.html`

## security considerations
[Note the any security considerations here, or make note of why there are none]
