### PR TITLE
dependabot for github action version update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,16 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Ignore minor and patch updates
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+    groups:
+      # Group all updates together
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Changes proposed in this pull request:
- dependabot for gh action
- only check major version, ignore minor/patch version
- combine multiple gh action update into one pr

## security considerations
[Note the any security considerations here, or make note of why there are none]
