### PR TITLE
no major version upgrade for 11ty packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    versioning-strategy: "increase"
+    ignore:
+      # Ignore major updates for 11ty packages
+      - dependency-name: "@11ty/*"
+        update-types: ["version-update:semver-major"]
     groups:
       # Group all npm updates together
       npm-packages:


### PR DESCRIPTION
Stop dependabot push breaking changes from 11ty packages.

## Changes proposed in this pull request:
- ignore @11ty package major version upgrade

## security considerations
[Note the any security considerations here, or make note of why there are none]
