### PR TITLE
Add Missing Meta Description Tags

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -3,6 +3,7 @@ permalink: ''
 layout: layouts/home
 title: Data.gov Home
 tagline: The home of the U.S. Government's open data
+excerpt: The home of the U.S. Government's open data
 ---
 
 <!-- Banner hero -->

--- a/pages/timeline.html
+++ b/pages/timeline.html
@@ -3,6 +3,7 @@ permalink: ''
 layout: layouts/timeline
 title: Data.gov Program Age
 tagline: Data.gov - The home of the U.S. Government's open data
+excerpt: The timeline of Data.gov.
 ---
 
 <section class="cd-timeline js-cd-timeline">
@@ -13,7 +14,9 @@ tagline: Data.gov - The home of the U.S. Government's open data
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>January 21, 2009</h2>
-                <p class="color-contrast-medium">Presidential <a href="https://www.archives.gov/files/cui/documents/2009-WH-memo-on-transparency-and-open-government.pdf" target="_blank">Memorandum</a> on Transparency and Open Government.</p>
+                <p class="color-contrast-medium">Presidential <a
+                        href="https://www.archives.gov/files/cui/documents/2009-WH-memo-on-transparency-and-open-government.pdf"
+                        target="_blank">Memorandum</a> on Transparency and Open Government.</p>
 
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2009</span>
@@ -27,7 +30,9 @@ tagline: Data.gov - The home of the U.S. Government's open data
 
             <div class="cd-timeline__content text-component">
                 <h2>May 21, 2009</h2>
-                <p class="color-contrast-medium">GSA launches <a href="https://web.archive.org/web/20090530020348/http://www.data.gov/" target="_blank">Data.gov</a></p>
+                <p class="color-contrast-medium">GSA launches <a
+                        href="https://web.archive.org/web/20090530020348/http://www.data.gov/"
+                        target="_blank">Data.gov</a></p>
 
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date"></span>
@@ -40,7 +45,9 @@ tagline: Data.gov - The home of the U.S. Government's open data
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>December 8, 2009</h2>
-                <p class="color-contrast-medium">Open Government <a href="https://obamawhitehouse.archives.gov/open/documents/open-government-directive" target="_blank">Directive</a> requiring agencies to post high-value datasets on Data.gov</p>
+                <p class="color-contrast-medium">Open Government <a
+                        href="https://obamawhitehouse.archives.gov/open/documents/open-government-directive"
+                        target="_blank">Directive</a> requiring agencies to post high-value datasets on Data.gov</p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date"></span>
                 </div>
@@ -52,7 +59,9 @@ tagline: Data.gov - The home of the U.S. Government's open data
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>June 11, 2012</h2>
-                <p class="color-contrast-medium">U.S. and India launch <a href="https://fedscoop.com/u-s-india-officially-launch-data-gov-in-a-box/" target="_blank">Open Government Platform</a> (open source package for government open data sites)</p>
+                <p class="color-contrast-medium">U.S. and India launch <a
+                        href="https://fedscoop.com/u-s-india-officially-launch-data-gov-in-a-box/" target="_blank">Open
+                        Government Platform</a> (open source package for government open data sites)</p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2012</span>
                 </div>
@@ -65,7 +74,9 @@ tagline: Data.gov - The home of the U.S. Government's open data
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>May 9, 2013</h2>
-                <p class="color-contrast-medium">Open Data Executive <a href="https://obamawhitehouse.archives.gov/the-press-office/2013/05/09/executive-order-making-open-and-machine-readable-new-default-government-" target="_blank">Order</a></p>
+                <p class="color-contrast-medium">Open Data Executive <a
+                        href="https://obamawhitehouse.archives.gov/the-press-office/2013/05/09/executive-order-making-open-and-machine-readable-new-default-government-"
+                        target="_blank">Order</a></p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2013</span>
                 </div>
@@ -77,7 +88,8 @@ tagline: Data.gov - The home of the U.S. Government's open data
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>May 9, 2013</h2>
-                <p class="color-contrast-medium">Open Data <a href="https://digital.gov/resources/open-data-policy-m-13-13/" target="_blank">Policy</a></p>
+                <p class="color-contrast-medium">Open Data <a
+                        href="https://digital.gov/resources/open-data-policy-m-13-13/" target="_blank">Policy</a></p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date"></span>
                 </div>
@@ -89,7 +101,8 @@ tagline: Data.gov - The home of the U.S. Government's open data
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>2014</h2>
-                <p class="color-contrast-medium">Data.gov team begins working in the open on <a href="https://github.com/GSA/data.gov" target="_blank">GitHub</a></p>
+                <p class="color-contrast-medium">Data.gov team begins working in the open on <a
+                        href="https://github.com/GSA/data.gov" target="_blank">GitHub</a></p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2014</span>
                 </div>
@@ -102,7 +115,9 @@ tagline: Data.gov - The home of the U.S. Government's open data
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>2015</h2>
-                <p class="color-contrast-medium">Launch of <a href="https://github.com/project-open-data/project-open-data.github.io" target="_blank">Project Open Data</a> on GitHub</p>
+                <p class="color-contrast-medium">Launch of <a
+                        href="https://github.com/project-open-data/project-open-data.github.io" target="_blank">Project
+                        Open Data</a> on GitHub</p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2015</span>
                 </div>
@@ -115,7 +130,9 @@ tagline: Data.gov - The home of the U.S. Government's open data
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>December 10, 2016</h2>
-                <p class="color-contrast-medium">Senate passes <a href="https://www.congress.gov/bill/114th-congress/senate-bill/2852?q=%7B%22search%22%3A%5B%22OPEN+Government+Data%22%5D%7D&s=6&r=1" target="_blank">OPEN Government Data Act</a></p>
+                <p class="color-contrast-medium">Senate passes <a
+                        href="https://www.congress.gov/bill/114th-congress/senate-bill/2852?q=%7B%22search%22%3A%5B%22OPEN+Government+Data%22%5D%7D&s=6&r=1"
+                        target="_blank">OPEN Government Data Act</a></p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2016</span>
                 </div>
@@ -128,8 +145,11 @@ tagline: Data.gov - The home of the U.S. Government's open data
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>December 21, 2018</h2>
-                <p class="color-contrast-medium">OPEN Government Data Act, incorporated into Foundations for Evidence-Based Policymaking <a href="https://www.congress.gov/bill/115th-congress/house-bill/4174/actions?s=4&r=1&q=%7B%22search%22%3A%5B%22Foundations+Evidence+Based%22%5D%7D" target="_blank">Act</a> passes both Houses of
-                Congress</p>
+                <p class="color-contrast-medium">OPEN Government Data Act, incorporated into Foundations for
+                    Evidence-Based Policymaking <a
+                        href="https://www.congress.gov/bill/115th-congress/house-bill/4174/actions?s=4&r=1&q=%7B%22search%22%3A%5B%22Foundations+Evidence+Based%22%5D%7D"
+                        target="_blank">Act</a> passes both Houses of
+                    Congress</p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2018</span>
                 </div>
@@ -142,7 +162,9 @@ tagline: Data.gov - The home of the U.S. Government's open data
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>January 14, 2019</h2>
-                <p class="color-contrast-medium">OPEN Government Data Act signed into <a href="https://www.congress.gov/115/plaws/publ435/PLAW-115publ435.pdf" target="_blank">law</a> (Data.gov required by statute)</p>
+                <p class="color-contrast-medium">OPEN Government Data Act signed into <a
+                        href="https://www.congress.gov/115/plaws/publ435/PLAW-115publ435.pdf" target="_blank">law</a>
+                    (Data.gov required by statute)</p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2019</span>
                 </div>
@@ -155,7 +177,8 @@ tagline: Data.gov - The home of the U.S. Government's open data
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>July 2019</h2>
-                <p class="color-contrast-medium">Launch of <a href="https://resources.data.gov/" target="_blank">resources.data.gov</a></p>
+                <p class="color-contrast-medium">Launch of <a href="https://resources.data.gov/"
+                        target="_blank">resources.data.gov</a></p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date"></span>
                 </div>
@@ -181,7 +204,8 @@ tagline: Data.gov - The home of the U.S. Government's open data
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>February 2021</h2>
-                <p class="color-contrast-medium">Data.gov catalog running updated <a href="https://ckan.org/" target="_blank">CKAN</a></p>
+                <p class="color-contrast-medium">Data.gov catalog running updated <a href="https://ckan.org/"
+                        target="_blank">CKAN</a></p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2021</span>
                 </div>
@@ -194,7 +218,8 @@ tagline: Data.gov - The home of the U.S. Government's open data
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>August 2022</h2>
-                <p class="color-contrast-medium">Completion of migration of Data.gov to <a href="https://cloud.gov/" target="_blank">Cloud.gov</a> infrastructure</p>
+                <p class="color-contrast-medium">Completion of migration of Data.gov to <a href="https://cloud.gov/"
+                        target="_blank">Cloud.gov</a> infrastructure</p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2022</span>
                 </div>
@@ -207,7 +232,8 @@ tagline: Data.gov - The home of the U.S. Government's open data
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>March 30, 2023</h2>
-                <p class="color-contrast-medium">Launch of redesigned Data.gov <a href="https://data.gov/" target="_blank">home</a> page</p>
+                <p class="color-contrast-medium">Launch of redesigned Data.gov <a href="https://data.gov/"
+                        target="_blank">home</a> page</p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2023</span>
                 </div>

--- a/pages/timeline.html
+++ b/pages/timeline.html
@@ -14,9 +14,7 @@ excerpt: The timeline of Data.gov.
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>January 21, 2009</h2>
-                <p class="color-contrast-medium">Presidential <a
-                        href="https://www.archives.gov/files/cui/documents/2009-WH-memo-on-transparency-and-open-government.pdf"
-                        target="_blank">Memorandum</a> on Transparency and Open Government.</p>
+                <p class="color-contrast-medium">Presidential <a href="https://www.archives.gov/files/cui/documents/2009-WH-memo-on-transparency-and-open-government.pdf" target="_blank">Memorandum</a> on Transparency and Open Government.</p>
 
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2009</span>
@@ -30,9 +28,7 @@ excerpt: The timeline of Data.gov.
 
             <div class="cd-timeline__content text-component">
                 <h2>May 21, 2009</h2>
-                <p class="color-contrast-medium">GSA launches <a
-                        href="https://web.archive.org/web/20090530020348/http://www.data.gov/"
-                        target="_blank">Data.gov</a></p>
+                <p class="color-contrast-medium">GSA launches <a href="https://web.archive.org/web/20090530020348/http://www.data.gov/" target="_blank">Data.gov</a></p>
 
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date"></span>
@@ -45,9 +41,7 @@ excerpt: The timeline of Data.gov.
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>December 8, 2009</h2>
-                <p class="color-contrast-medium">Open Government <a
-                        href="https://obamawhitehouse.archives.gov/open/documents/open-government-directive"
-                        target="_blank">Directive</a> requiring agencies to post high-value datasets on Data.gov</p>
+                <p class="color-contrast-medium">Open Government <a href="https://obamawhitehouse.archives.gov/open/documents/open-government-directive" target="_blank">Directive</a> requiring agencies to post high-value datasets on Data.gov</p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date"></span>
                 </div>
@@ -59,9 +53,7 @@ excerpt: The timeline of Data.gov.
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>June 11, 2012</h2>
-                <p class="color-contrast-medium">U.S. and India launch <a
-                        href="https://fedscoop.com/u-s-india-officially-launch-data-gov-in-a-box/" target="_blank">Open
-                        Government Platform</a> (open source package for government open data sites)</p>
+                <p class="color-contrast-medium">U.S. and India launch <a href="https://fedscoop.com/u-s-india-officially-launch-data-gov-in-a-box/" target="_blank">Open Government Platform</a> (open source package for government open data sites)</p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2012</span>
                 </div>
@@ -74,9 +66,7 @@ excerpt: The timeline of Data.gov.
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>May 9, 2013</h2>
-                <p class="color-contrast-medium">Open Data Executive <a
-                        href="https://obamawhitehouse.archives.gov/the-press-office/2013/05/09/executive-order-making-open-and-machine-readable-new-default-government-"
-                        target="_blank">Order</a></p>
+                <p class="color-contrast-medium">Open Data Executive <a href="https://obamawhitehouse.archives.gov/the-press-office/2013/05/09/executive-order-making-open-and-machine-readable-new-default-government-" target="_blank">Order</a></p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2013</span>
                 </div>
@@ -88,8 +78,7 @@ excerpt: The timeline of Data.gov.
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>May 9, 2013</h2>
-                <p class="color-contrast-medium">Open Data <a
-                        href="https://digital.gov/resources/open-data-policy-m-13-13/" target="_blank">Policy</a></p>
+                <p class="color-contrast-medium">Open Data <a href="https://digital.gov/resources/open-data-policy-m-13-13/" target="_blank">Policy</a></p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date"></span>
                 </div>
@@ -101,8 +90,7 @@ excerpt: The timeline of Data.gov.
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>2014</h2>
-                <p class="color-contrast-medium">Data.gov team begins working in the open on <a
-                        href="https://github.com/GSA/data.gov" target="_blank">GitHub</a></p>
+                <p class="color-contrast-medium">Data.gov team begins working in the open on <a href="https://github.com/GSA/data.gov" target="_blank">GitHub</a></p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2014</span>
                 </div>
@@ -115,9 +103,7 @@ excerpt: The timeline of Data.gov.
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>2015</h2>
-                <p class="color-contrast-medium">Launch of <a
-                        href="https://github.com/project-open-data/project-open-data.github.io" target="_blank">Project
-                        Open Data</a> on GitHub</p>
+                <p class="color-contrast-medium">Launch of <a href="https://github.com/project-open-data/project-open-data.github.io" target="_blank">Project Open Data</a> on GitHub</p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2015</span>
                 </div>
@@ -130,9 +116,7 @@ excerpt: The timeline of Data.gov.
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>December 10, 2016</h2>
-                <p class="color-contrast-medium">Senate passes <a
-                        href="https://www.congress.gov/bill/114th-congress/senate-bill/2852?q=%7B%22search%22%3A%5B%22OPEN+Government+Data%22%5D%7D&s=6&r=1"
-                        target="_blank">OPEN Government Data Act</a></p>
+                <p class="color-contrast-medium">Senate passes <a href="https://www.congress.gov/bill/114th-congress/senate-bill/2852?q=%7B%22search%22%3A%5B%22OPEN+Government+Data%22%5D%7D&s=6&r=1" target="_blank">OPEN Government Data Act</a></p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2016</span>
                 </div>
@@ -145,11 +129,8 @@ excerpt: The timeline of Data.gov.
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>December 21, 2018</h2>
-                <p class="color-contrast-medium">OPEN Government Data Act, incorporated into Foundations for
-                    Evidence-Based Policymaking <a
-                        href="https://www.congress.gov/bill/115th-congress/house-bill/4174/actions?s=4&r=1&q=%7B%22search%22%3A%5B%22Foundations+Evidence+Based%22%5D%7D"
-                        target="_blank">Act</a> passes both Houses of
-                    Congress</p>
+                <p class="color-contrast-medium">OPEN Government Data Act, incorporated into Foundations for Evidence-Based Policymaking <a href="https://www.congress.gov/bill/115th-congress/house-bill/4174/actions?s=4&r=1&q=%7B%22search%22%3A%5B%22Foundations+Evidence+Based%22%5D%7D" target="_blank">Act</a> passes both Houses of
+                Congress</p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2018</span>
                 </div>
@@ -162,9 +143,7 @@ excerpt: The timeline of Data.gov.
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>January 14, 2019</h2>
-                <p class="color-contrast-medium">OPEN Government Data Act signed into <a
-                        href="https://www.congress.gov/115/plaws/publ435/PLAW-115publ435.pdf" target="_blank">law</a>
-                    (Data.gov required by statute)</p>
+                <p class="color-contrast-medium">OPEN Government Data Act signed into <a href="https://www.congress.gov/115/plaws/publ435/PLAW-115publ435.pdf" target="_blank">law</a> (Data.gov required by statute)</p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2019</span>
                 </div>
@@ -177,8 +156,7 @@ excerpt: The timeline of Data.gov.
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>July 2019</h2>
-                <p class="color-contrast-medium">Launch of <a href="https://resources.data.gov/"
-                        target="_blank">resources.data.gov</a></p>
+                <p class="color-contrast-medium">Launch of <a href="https://resources.data.gov/" target="_blank">resources.data.gov</a></p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date"></span>
                 </div>
@@ -204,8 +182,7 @@ excerpt: The timeline of Data.gov.
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>February 2021</h2>
-                <p class="color-contrast-medium">Data.gov catalog running updated <a href="https://ckan.org/"
-                        target="_blank">CKAN</a></p>
+                <p class="color-contrast-medium">Data.gov catalog running updated <a href="https://ckan.org/" target="_blank">CKAN</a></p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2021</span>
                 </div>
@@ -218,8 +195,7 @@ excerpt: The timeline of Data.gov.
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>August 2022</h2>
-                <p class="color-contrast-medium">Completion of migration of Data.gov to <a href="https://cloud.gov/"
-                        target="_blank">Cloud.gov</a> infrastructure</p>
+                <p class="color-contrast-medium">Completion of migration of Data.gov to <a href="https://cloud.gov/" target="_blank">Cloud.gov</a> infrastructure</p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2022</span>
                 </div>
@@ -232,8 +208,7 @@ excerpt: The timeline of Data.gov.
             </div>
             <div class="cd-timeline__content text-component">
                 <h2>March 30, 2023</h2>
-                <p class="color-contrast-medium">Launch of redesigned Data.gov <a href="https://data.gov/"
-                        target="_blank">home</a> page</p>
+                <p class="color-contrast-medium">Launch of redesigned Data.gov <a href="https://data.gov/" target="_blank">home</a> page</p>
                 <div class="flex justify-between items-center">
                     <span class="cd-timeline__date">2023</span>
                 </div>


### PR DESCRIPTION
Relates to:
GSA/data.gov#5075
## Changes proposed in this pull request:
- Adds missing `excerpts` to the Home page, and Timeline

Screenshots:
![Screenshot from 2025-02-26 12-08-45](https://github.com/user-attachments/assets/62fc51cb-782b-4a63-89c7-97032960de2f)
_(Screenshot showing the meta description is now populated on the `/timeline` page)_
![Screenshot from 2025-02-26 12-09-53](https://github.com/user-attachments/assets/40777073-f829-434a-b5bc-fd03941b69b9)
_(Screenshot showing the meta description is now populated on the `/` (home/index) page)_


## security considerations
[Note the any security considerations here, or make note of why there are none]
