### PR TITLE
create issue on snyk failure

### DIFF
--- a/.github/snyk_failure.md
+++ b/.github/snyk_failure.md
@@ -1,0 +1,9 @@
+---
+title: Snyk Check Failed
+labels: ["bug", "o&m", "compliance"]
+---
+
+Workflow with Issue: {{ workflow }}
+Job Failed: {{ env.GITHUB_JOB }}
+
+Github Action Run: https://github.com/GSA/datagov-11ty/actions/runs/{{ env.RUN_ID }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '0 5 * * *'  # Run at midnight Eastern Time every day (midnight EST/1 AM EDT)
+    - cron: '0 5 * * 1-5'  # Run at midnight EST/1 AM EDT on weekdays (Mon-Fri)
   workflow_dispatch:  # Allow manual triggering
 
 jobs:
@@ -32,5 +32,16 @@ jobs:
         run: snyk auth ${{ secrets.SNYK_TOKEN }}
 
       - name: Run Snyk test for vulnerabilities
-        run: snyk test --severity-threshold=high
-        continue-on-error: true
+        run: snyk test --severity-threshold=medium
+
+      - name: Create Issue for failure 😢
+        if: ${{ failure() }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_JOB: ${{ toJson(github)['job'] }}
+          GITHUB_ATTEMPTS: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
+        with:
+          filename: .github/snyk_failure.md
+          update_existing: true


### PR DESCRIPTION
## Changes proposed in this pull request:
- create ticket when snyk test finds something
- change snyk test severity from high to medium
- change nightly snyk test to weekday-ly, meaning less snyk free quota usage.

TODO: 
change the `secrets.GITHUB_TOKEN`  to one that has capability to add ticket to project board.

## security considerations
[Note the any security considerations here, or make note of why there are none]
