### PR TITLE
remove 15 year anniversary content

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,3 +1,0 @@
-<div class="banner padding-2 text-center">
-    CELEBRATING <b>15 YEARS</b> OF DATA.GOV
-</div>

--- a/_includes/layouts/base.html
+++ b/_includes/layouts/base.html
@@ -15,8 +15,6 @@ The home page uses wide.html layout, since it extends full width of page
   {% include "menu.html" primary_navigation: site.primary_navigation secondary_navigation: site.secondary_navigation
   %}
 
-  {% include "banner.html" %}
-
   {{ content }}
 
   {% include "footer.html" %}

--- a/cypress/e2e/home_page.cy.js
+++ b/cypress/e2e/home_page.cy.js
@@ -15,6 +15,14 @@ describe('The Home Page', () => {
         });
     });
 
+    describe('Anniversary', () => {
+        it('doesn\'t have the 15 year anniversary banner', () => {
+            cy.get('div.banner.padding-2.text-center').should('not.exist');
+        })
+        it('doesn\'t have the anniversary section', ()=> {
+            cy.get('section.usa-section.anniversary').should('not.exist');
+        })
+    })
     describe('Hero', () => {
         it('has the expected title', () => {
             cy.get('h1').contains("The Home of the U.S. Government's Open Data");
@@ -26,6 +34,15 @@ describe('The Home Page', () => {
     });
 
     describe('The Metrics Widgets', () => {
+        it('has the metrics section', ()=> {
+            cy.get('section.usa-section.metrics').should('exist');
+        })
+        it('has a title', () => {
+            cy.get('section.usa-section.metrics').find('h1').contains('Metrics')
+        })
+        it('has a description', () => {
+            cy.get('section.usa-section.metrics').find('div:not([class])').contains(' Below')
+        })
         it('has a bar chart by org type', () => {
             cy.get('#datagov-bar-chart-org').should('be.visible').should('have.data', 'metric');
         });

--- a/pages/index.html
+++ b/pages/index.html
@@ -71,42 +71,17 @@ excerpt: The home of the U.S. Government's open data
             agency missions</b>, and
           <b>strengthen the foundation of an open and transparent government</b>.
         </div>
-        <div class="grid-row-auto margin-top-3">
-          <a href="{% page '/about/' %}" class="usa-button usa-button--secondary">
-            About Us {% usa_icon "arrow_forward" %}
-          </a>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- Anniversary  -->
-<section class="usa-section anniversary">
-  <div class="grid-container">
-    <div class="grid-row grid-gap-lg">
-      <div class="grid-col-12 desktop:grid-col-4">
-        <img class="datagov-age-icon" alt="Data Gov is 14yrs old!" role="img"
-          src="https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/15-years-anniversary-graphic.jpg" />
-      </div>
-      <div class="grid-col-12 desktop:grid-col-8">
-        <h1>Data.gov at 15</h1>
-        <div>
-          On May 21, 2009, Data.gov launched with a total of 47 datasets. After the landmark 2013 <a
-            href="https://digital.gov/resources/open-data-policy-m-13-13/" target="_blank">Open Data Policy</a>
-          required agencies to create comprehensive data inventories and public data listings, the site grew to 115,000+
-          datasets from 88 organizations by 2015. These requirements were enacted into the <a
-            href="https://www.congress.gov/115/plaws/publ435/PLAW-115publ435.pdf" target="_blank">Open Government Data
-            Act</a> in
-          2019. Today, Data.gov is nearing 300,000 datasets and dataset collections in the catalog, harvested from over
-          100 organizations, and counts over a million monthly pageviews from people like you, looking to discover that
-          information. In 2024, Data.gov continues its commitment to open government data and transparency. Thank you
-          for 15 years!
-        </div>
-        <div class="grid-row-auto margin-top-3">
-          <a href="{% page '/timeline/' %}" class="usa-button usa-button--secondary">
-            Explore the timeline {% usa_icon "arrow_forward" %}
-          </a>
+        <div class="buttons">
+          <div class="grid-row-auto margin-top-3">
+            <a href="{% page '/about/' %}" class="usa-button usa-button--secondary">
+              About Us {% usa_icon "arrow_forward" %}
+            </a>
+          </div>
+          <div class="grid-row-auto margin-top-3">
+            <a href="{% page '/timeline/' %}" class="usa-button usa-button--secondary">
+              Explore the timeline {% usa_icon "arrow_forward" %}
+            </a>
+          </div>
         </div>
       </div>
     </div>
@@ -116,7 +91,16 @@ excerpt: The home of the U.S. Government's open data
 <!-- Metrics Tiles  -->
 <section class="usa-section metrics">
   <div class="grid-container">
-    <div class="grid-row grid-gap-lg">
+    <h1 class="text-center">Metrics</h1>
+    <div>
+      Below, you can view breakdowns of the type, age, and distribution of 
+      <a href="https://catalog.data.gov/" target="_blank">catalog.data.gov</a>
+      datasets. For information on top dataset page views, file downloads, and external link 
+      clicks broken down by agency, see <a href="https://data.gov/metrics" target="_blank">data.gov/metrics</a>.
+      To learn more about the Metrics section, see the 
+      <a href="https://digital.gov/2024/09/13/datagov-launches-metrics-tools/" target="_blank">Digital.gov blog post.</a>
+    </div>
+    <div class="grid-row grid-gap-lg margin-top-3">
       <div class="grid-col-12 desktop:grid-col-8">
         <!-- Key Metric by Organization Type -->
         {% if catalog and catalog.metrics and catalog.metrics.orgBarMetric %}

--- a/styles/partials/datagovtheme.scss
+++ b/styles/partials/datagovtheme.scss
@@ -11,8 +11,6 @@ $s3_image_about_us_card_bg: 'https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-
 $s3_image_mission_graphic: 'https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/mission-graphic.svg';
 $s3_image_mission_section_bg: 'https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/mission-section-bg.png';
 
-$s3_anniversary_banner: 'https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/15-years-anniversary-banner-2912px.jpg';
-
 a {
     color: color('blue-warm-60v');
 
@@ -114,26 +112,6 @@ html.datagov {
     }
 }
 
-.banner {
-    background-image: url($s3_anniversary_banner);
-    background-size: cover;
-    // background-color: color('primary-vivid');
-    color: white;
-    
-    @include at-media('mobile') {
-        background-position-x: 35%;
-    }
-
-    @include at-media('tablet') {
-        background-position-x: 0%;
-    }
-
-    a {
-        color: white;
-        text-decoration: underline;
-    }
-}
-
 .hero {
     background-image: url($s3_image_hero_image_bg);
     background-repeat: no-repeat;
@@ -204,18 +182,17 @@ html.datagov {
         }
     }
 
+    .buttons {
+        display: flex; 
+        justify-content: space-evenly;
+    }
+
     position: relative;
     border-bottom: 1px solid color('gray-10');
     margin: auto;
     text-align: center;
 }
 
-.anniversary {
-    text-align: center;
-    @include at-media('desktop') {
-        text-align: left;
-    }
-}
 .mediabox {
     border: 2px solid color('gray-10');
     padding: 20px;


### PR DESCRIPTION
## Changes proposed in this pull request:
- related to [#5074](https://github.com/GSA/data.gov/issues/5074)
- remove 15-year anniversary content
- see [preview](https://federalist-2ac784db-2321-4734-8d02-933835d88304.sites.pages.cloud.gov/preview/gsa/datagov-11ty/remove-15-year-content/)


## security considerations
[Note the any security considerations here, or make note of why there are none]
