### PR TITLE
ci: allow Snyk scan on Dependabot PRs via pull_request_target

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -3,6 +3,8 @@ name: Snyk Scan
 on:
   pull_request:
     branches: [ main ]
+  pull_request_target:
+    branches: [ main ]
   schedule:
     - cron: '0 5 * * 1-5'  # Run at midnight EST/1 AM EDT on weekdays (Mon-Fri)
   workflow_dispatch:  # Allow manual triggering
@@ -11,9 +13,20 @@ jobs:
   snyk:
     name: Snyk Scan
     runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]') ||
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
+      (github.event_name != 'pull_request' && github.event_name != 'pull_request_target')
 
     steps:
+      - name: Checkout source (Dependabot PR)
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Checkout source
+        if: ${{ github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v5
 
       - name: Setup Node.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -7144,7 +7144,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {


### PR DESCRIPTION
Forked PRs do not have access the secrets, therefore snyk auth has been failing on PRs from dependabot. 

This commit detects PRs from dependabot and uses `pull_request_target` so that it has access to synk token secrets.