### PR TITLE
Catalog Update Post (Merge on Cutover)

### DIFF
--- a/pages/posts/2026-04-15-catalog-update.md
+++ b/pages/posts/2026-04-15-catalog-update.md
@@ -9,7 +9,7 @@ modified: '2026-04-15T12:00:00'
 permalink: "blog/catalog-update/"
 slug: catalog-update
 
-title: Notice: catalog.data.gov is being updated
+title: "Notice: catalog.data.gov is being updated"
 ---
 
 Notice: catalog.data.gov is being updated

--- a/pages/posts/2026-04-15-catalog-update.md
+++ b/pages/posts/2026-04-15-catalog-update.md
@@ -9,7 +9,7 @@ modified: '2026-04-15T12:00:00'
 permalink: "blog/catalog-update/"
 slug: catalog-update
 
-title: "Notice: catalog.data.gov is being updated"
+title: "Notice: catalog.data.gov Is Being Updated"
 ---
 
 The Data.gov team is launching a new version of the Data.gov catalog. This update replaces an aging system with a modern, maintainable platform built to support the long-term reliability of federal open data access.

--- a/pages/posts/2026-04-15-catalog-update.md
+++ b/pages/posts/2026-04-15-catalog-update.md
@@ -12,8 +12,6 @@ slug: catalog-update
 title: "Notice: catalog.data.gov is being updated"
 ---
 
-Notice: catalog.data.gov is being updated
-
 The Data.gov team is launching a new version of the Data.gov catalog. This update replaces an aging system with a modern, maintainable platform built to support the long-term reliability of federal open data access.
 
 The new system delivers improved search performance and a more stable foundation for ongoing development. During this transition, the previous catalog remains available at catalog-old.data.gov.

--- a/pages/posts/2026-04-15-catalog-update.md
+++ b/pages/posts/2026-04-15-catalog-update.md
@@ -14,8 +14,8 @@ title: "Notice: catalog.data.gov Is Being Updated"
 
 The Data.gov team is launching a new version of the Data.gov catalog. This update replaces an aging system with a modern, maintainable platform built to support the long-term reliability of federal open data access.
 
-The new system delivers improved search performance and a more stable foundation for ongoing development. During this transition, the previous catalog remains available at catalog-old.data.gov.
+The new system delivers improved search performance and a more stable foundation for ongoing development. During this transition, the previous catalog remains available at [catalog-old.data.gov](https://catalog-old.data.gov).
 
-If you are a data provider looking for high level information about your data on data.gov, please visit harvest.data.gov.
+If you are a data provider looking for high level information about your data on data.gov, please visit [harvest.data.gov](https://harvest.data.gov).
 
-If you encounter issues, please contact the Data.gov team via the feedback link on the site.
+If you encounter issues, please contact the Data.gov team via the [feedback link on the site](https://data.gov/contact/).

--- a/pages/posts/2026-04-15-catalog-update.md
+++ b/pages/posts/2026-04-15-catalog-update.md
@@ -1,0 +1,23 @@
+---
+categories:
+- meta
+date: '2026-04-15T12:00:00'
+excerpt: |-
+    The Data.gov team is launching a new version of the Data.gov catalog. This update replaces an aging system with a modern, maintainable platform built to support the long-term reliability of federal open data access....
+link: "https://www.data.gov/blog/catalog-update/"
+modified: '2026-04-15T12:00:00'
+permalink: "blog/catalog-update/"
+slug: catalog-update
+
+title: Notice: catalog.data.gov is being updated
+---
+
+Notice: catalog.data.gov is being updated
+
+The Data.gov team is launching a new version of the Data.gov catalog. This update replaces an aging system with a modern, maintainable platform built to support the long-term reliability of federal open data access.
+
+The new system delivers improved search performance and a more stable foundation for ongoing development. During this transition, the previous catalog remains available at catalog-old.data.gov.
+
+If you are a data provider looking for high level information about your data on data.gov, please visit harvest.data.gov.
+
+If you encounter issues, please contact the Data.gov team via the feedback link on the site.


### PR DESCRIPTION
## Changes proposed in this pull request:
Ticket: GSA/data.gov#5855

- creates a new blog post announcing the launch of new catalog.data.gov

Post Details:
```md
link: "https://www.data.gov/blog/catalog-update/"
permalink: "blog/catalog-update/"
slug: catalog-update

title: "Notice: catalog.data.gov Is Being Updated"
```
Links:
- Post Page: https://federalist-2ac784db-2321-4734-8d02-933835d88304.sites.pages.cloud.gov/preview/gsa/datagov-11ty/5855-catalog-update-post/blog/catalog-update/
- Blog List View: https://federalist-2ac784db-2321-4734-8d02-933835d88304.sites.pages.cloud.gov/preview/gsa/datagov-11ty/5855-catalog-update-post/updates/1/ (should be at the top)

## security considerations
[Note the any security considerations here, or make note of why there are none]
