### PR TITLE
Point Search Box to New Catalog

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -26,7 +26,7 @@ excerpt: The home of the U.S. Government's open data
         </div>
       </div>
       <section aria-label="Search component" class="hero__search">
-        <form class="usa-search" role="search" method="get" action="https://catalog.data.gov/dataset">
+        <form class="usa-search" role="search" method="get" action="https://catalog.data.gov">
           <label class="usa-sr-only" for="search-field">Search</label>
           <input class="usa-input" id="search-field" type="search" name="q" />
           <button class="usa-button" type="submit">


### PR DESCRIPTION
## Changes proposed in this pull request:
- it's because of the trailing slash causes it to point at the old catalog

## security considerations
[Note the any security considerations here, or make note of why there are none]
