### PR TITLE
Add explicit workflow token permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Build & Test
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/content_scan.yml
+++ b/.github/workflows/content_scan.yml
@@ -3,6 +3,9 @@ name: Content scan
 on:
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Content scan

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 15 * * 1'
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   qa:
     uses: gsa/data.gov/.github/workflows/static-site-qa-template.yml@main

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -7,6 +7,10 @@ on:
     - cron: '0 5 * * 1-5'  # Run at midnight EST/1 AM EDT on weekdays (Mon-Fri)
   workflow_dispatch:  # Allow manual triggering
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   snyk:
     name: Snyk Scan

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -9,10 +9,6 @@ permissions:
   contents: read
   issues: write
 
-permissions:
-  contents: read
-  issues: write
-
 jobs:
   snyk:
     uses: GSA/data.gov/.github/workflows/snyk-template.yml@main


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks in:
  - `.github/workflows/content_scan.yml` (`contents: read`)
  - `.github/workflows/snyk.yml` (`contents: read`, `issues: write`)

## Why
These workflows currently rely on implicit token defaults. Explicit scopes enforce least privilege while preserving issue-creation behavior in the Snyk workflow.