### PR TITLE
fix metrics table caption accessibility

### DIFF
--- a/pages/metrics/metrics.html
+++ b/pages/metrics/metrics.html
@@ -57,17 +57,17 @@ title: Datagov Metrics Dashboard
     {% else %}
     <div class="grid-row grid-gap-lg {{cacheKey}}">
       <div class="grid-col-12">
-        <h4>{{block.meta.title}}</h4>
+        <h4 id="metrics-{{cacheKey}}">{{block.meta.title}}</h4>
         <p>{{block.meta.description}}</p>
+        <p>
+          <a href="{{block.meta.reportLink}}">{% usa_icon 'file_download' %} Download Full Report -
+            {{block.meta.title}}</a>
+        </p>
         {%- if cacheKey == "MOST_DOWNLOADED_DATASETS" or cacheKey == "MOST_CLICKED_OUTBOUND_LINKS"-%}
-          <table class="usa-table usa-table--borderless usa-table--stacked">
+          <table class="usa-table usa-table--borderless usa-table--stacked" aria-labelledby="metrics-{{cacheKey}}">
         {%- else -%}
-          <table class="usa-table usa-table--borderless usa-table--stacked full-width"> 
+          <table class="usa-table usa-table--borderless usa-table--stacked full-width" aria-labelledby="metrics-{{cacheKey}}">
         {%- endif -%}
-          <caption>
-            <a href="{{block.meta.reportLink}}">{% usa_icon 'file_download' %} Download Full Report -
-              {{block.meta.title}}</a>
-          </caption>
           <thead>
             <tr>
               {% for data in block.data[0] %}

--- a/pages/metrics/metrics_per-org.html
+++ b/pages/metrics/metrics_per-org.html
@@ -24,19 +24,19 @@ eleventyComputed:
     {% assign cacheKey = block.meta.key %}
     <div class="grid-row grid-gap-lg {{cacheKey}}">
       <div class="grid-col-12">
-        <h4>{{block.meta.title}}</h4>
+        <h4 id="metrics-{{org.name}}-{{cacheKey}}">{{block.meta.title}}</h4>
         <p>{{block.meta.description}}</p>
         {% # The first row is headers, we need more than one row to have actual data %}
         {% if block.data.length > 1 %}
+          <p>
+            <a href="{{block.meta.reportLink}}">{% usa_icon 'file_download' %} Download Full Report -
+              {{block.meta.title}}</a>
+          </p>
           {%- if cacheKey == "MOST_VIEWED_DATASETS" -%}
-            <table class="usa-table usa-table--borderless usa-table--stacked full-width">
+            <table class="usa-table usa-table--borderless usa-table--stacked full-width" aria-labelledby="metrics-{{org.name}}-{{cacheKey}}">
           {%- else -%}
-            <table class="usa-table usa-table--borderless usa-table--stacked"> 
+            <table class="usa-table usa-table--borderless usa-table--stacked" aria-labelledby="metrics-{{org.name}}-{{cacheKey}}">
           {%- endif -%}
-            <caption>
-              <a href="{{block.meta.reportLink}}">{% usa_icon 'file_download' %} Download Full Report -
-                {{block.meta.title}}</a>
-            </caption>
             <thead>
               <tr>
                 {% for data in block.data[0] %}


### PR DESCRIPTION
For
- https://github.com/GSA/data.gov/issues/6166#issuecomment-4958562327

`npm run pa11y-ci` in content scan is failing. The fix removes the fragile part: no `<caption>` inside these tables.

## Changes proposed in this pull request:
- remove `<caption>` from within tables, add “Download Full Report” link above tables.
- to keep the tables accessible, add id to heading and add aria-labelledby to the tables.