### PR TITLE
Refactor dataset calculation in catalog.js

### DIFF
--- a/_data/catalog.js
+++ b/_data/catalog.js
@@ -23,13 +23,11 @@ const buildPieMetric = (results) => {
 module.exports = async function () {
     try {
         const stats = await EleventyFetch(CATALOG_STATS_URL, CACHE_CONFIG);
-        const totalDatasets = stats?.results?.datasets ?? 0;
+        const datasets = stats?.results?.datasets ?? 0;
         const datasetsInCollections = stats?.results?.datasetsWithIsPartOf ?? 0;
-        const datasets = Math.max(totalDatasets - datasetsInCollections, 0);
         const results = {
             ...(stats?.results || {}),
             datasets,
-            totalDatasets,
             datasetsInCollections,
         };
         const metrics = {


### PR DESCRIPTION
Remove the weird reporting around collections, we don't think this way anymore. The dataset count on catalog should match what is on data.gov.

## security considerations
None.
