### PR TITLE
6092: Replace Strategy section of homepage with SHARE IT & Code Section  

### DIFF
--- a/cypress/e2e/home_page.cy.js
+++ b/cypress/e2e/home_page.cy.js
@@ -53,4 +53,19 @@ describe('The Home Page', () => {
             cy.get('#datagov-pie-chart').should('be.visible').should('have.data', 'metric');
         });
     });
+
+    describe('SHARE IT Act Section', () => {
+        it('has the code repositories section', () => {
+            cy.get('section.usa-section.code-repositories').should('exist');
+        });
+        it('has a title mentioning source code or repositories', () => {
+            cy.get('section.usa-section.code-repositories').find('h2').should('contain.text', 'Source Code');
+        });
+        it('has a link to the /code page', () => {
+            cy.get('section.usa-section.code-repositories').find('a[href*="/code"]').should('exist');
+        });
+        it('does not display Federal Data Strategy section', () => {
+            cy.get('section.usa-section.sibling-sites').should('not.contain.text', 'Strategy');
+        });
+    });
 });

--- a/pages/index.html
+++ b/pages/index.html
@@ -139,6 +139,30 @@ excerpt: The home of the U.S. Government's open data
   </div>
 </section>
 
+<!-- Code Repositories -->
+<section class="usa-section code-repositories">
+  <div class="grid-container">
+    <div class="grid-row grid-gap-lg">
+      <div class="tablet:grid-col-8">
+        <h2 class="font-heading-xl margin-top-0">Federal Source Code Repositories</h2>
+        <p class="font-body-lg">
+          The SHARE IT Act (Public Law 118-187) requires federal agencies to maintain
+          source code repositories and make them publicly discoverable through Data.gov.
+        </p>
+        <p>
+          Explore agency code repositories, track compliance status, and discover
+          open source projects from across the federal government.
+        </p>
+      </div>
+      <div class="tablet:grid-col-4 display-flex flex-align-center">
+        <a class="usa-button usa-button--big" href="https://catalog.data.gov/code">
+          View Code Repositories
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+
 <!-- Sibling sites  -->
 <section class="usa-section sibling-sites">
   <div class="grid-container">

--- a/pages/index.html
+++ b/pages/index.html
@@ -157,20 +157,6 @@ excerpt: The home of the U.S. Government's open data
           {% endfor %}
         </ul>
       </div>
-      <div class="grid-col-12 desktop:grid-col-6">
-        <div class="logo">
-          <a href="{% link site.links.sites.strategy %}">
-            {% image "strategy-logo.svg" "Strategy Logo" false %}
-          </a>
-        </div>
-        <ul class="quick-links--strategy">
-          {% for link in site.strategy_quick_links %}
-          <li>
-            <a href="{% link link.url %}">{{ link.title }} {% usa_icon 'launch' %}</a>
-          </li>
-          {% endfor %}
-        </ul>
-      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
PR for [Issue #6092](https://github.com/GSA/data.gov/issues/6092). This is to replace the Federal Data Strategy section of the static site's homepage with the code repo links page implemented [here](https://github.com/GSA/datagov-catalog/pull/407).